### PR TITLE
Replace code of conduct public Discord to INSERT CONTACT HERE

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -59,7 +59,8 @@ representative at an online or offline event.
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported to the community leaders responsible for enforcement at our public Discord: https://discord.gg/3Dcwpj4YnD.
+reported to the community leaders responsible for enforcement at
+(CONTACT METHOD HERE).
 All complaints will be reviewed and investigated promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the


### PR DESCRIPTION
People using this template have a templated code of conduct when this is merged.